### PR TITLE
Add volume normalization between tracks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playhead",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playhead",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@fontsource/geist-mono": "^5.2.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playhead",
   "productName": "Playhead",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Local-first desktop music player prototype with waveform playback.",
   "author": "Edin",
   "license": "MIT",

--- a/src/main/library/__tests__/store.test.ts
+++ b/src/main/library/__tests__/store.test.ts
@@ -58,6 +58,7 @@ describe("library store settings", () => {
     expect(defaultPlaybackSettings()).toEqual({
       seekStepSeconds: 5,
       volumeStepPercent: 5,
+      normalizeVolume: false,
       rememberTrackPositions: true,
       restoreLastSession: true,
       skipUnavailableTracks: true,

--- a/src/main/library/library-ipc.ts
+++ b/src/main/library/library-ipc.ts
@@ -245,6 +245,11 @@ export function registerLibraryIpc(): void {
     return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
   });
 
+  ipcMain.handle("library:get-audio-file-revision", async (_event, filePath: string) => {
+    const fileInfo = await stat(filePath);
+    return { size: fileInfo.size, mtimeMs: fileInfo.mtimeMs };
+  });
+
   ipcMain.handle("library:get-waveform-cache", async (_event, request: WaveformCacheRequest) => {
     return readWaveformCache(request, {
       directory: join(app.getPath("userData"), "waveforms"),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -38,6 +38,8 @@ const api: PlayheadApi = {
   getDroppedFilePath: (file: File) => webUtils.getPathForFile(file),
   getAudioFileUrl: (path: string) => ipcRenderer.invoke("library:get-audio-url", path),
   readAudioFile: (path: string) => ipcRenderer.invoke("library:read-audio-file", path),
+  getAudioFileRevision: (path: string) =>
+    ipcRenderer.invoke("library:get-audio-file-revision", path),
   getWaveformCache: (request: WaveformCacheRequest) =>
     ipcRenderer.invoke("library:get-waveform-cache", request),
   saveWaveformCache: (write: WaveformCacheWrite) =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -73,6 +73,11 @@ import {
   waveformAnalysisMaxPeaks,
   waveformAnalysisPeakRate,
 } from "@/features/audio/audio-analysis";
+import { PlaybackVolumeController } from "@/features/audio/playback-volume";
+import {
+  analyzeTrackNormalizationGain,
+  getCachedTrackNormalizationGain,
+} from "@/features/audio/volume-normalization";
 import {
   emptyLibraryState,
   createPlaylist,
@@ -408,6 +413,18 @@ export function App() {
   const rememberTrackPositionRef = useRef<(trackId: string, time: number) => void>(() => {});
   const clearTrackPositionRef = useRef<(trackId: string) => void>(() => {});
   const volumeRef = useRef(1);
+  const volumeControllerRef = useRef<PlaybackVolumeController | null>(null);
+  if (!volumeControllerRef.current) {
+    volumeControllerRef.current = new PlaybackVolumeController((nextVolume) => {
+      wavesurferRef.current?.setVolume(nextVolume);
+    });
+  }
+  useEffect(
+    () => () => {
+      volumeControllerRef.current?.dispose();
+    },
+    [],
+  );
   const didLoadLibraryRef = useRef(false);
   const didRestoreSessionRef = useRef(false);
   const lastPositionSaveRef = useRef(0);
@@ -2113,10 +2130,9 @@ export function App() {
   }, [activeTrack, activeTrackId, allPlayableTracksById, selectTrack, selectedTrackIds, tracks]);
 
   const setPlayerVolume = useCallback((nextVolume: number) => {
-    const clampedVolume = clamp(nextVolume, 0, 1);
-    volumeRef.current = clampedVolume;
-    setVolume(clampedVolume);
-    wavesurferRef.current?.setVolume(clampedVolume);
+    const baseVolume = volumeControllerRef.current?.setBaseVolume(nextVolume) ?? 1;
+    volumeRef.current = baseVolume;
+    setVolume(baseVolume);
   }, []);
 
   const seekBy = useCallback((offset: number) => {
@@ -2134,11 +2150,37 @@ export function App() {
 
   const changeVolumeBy = useCallback(
     (offset: number) => {
-      const wavesurfer = wavesurferRef.current;
-      setPlayerVolume((wavesurfer?.getVolume() ?? volumeRef.current) + offset);
+      setPlayerVolume((volumeControllerRef.current?.getBaseVolume() ?? volumeRef.current) + offset);
     },
     [setPlayerVolume],
   );
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    const controller = volumeControllerRef.current;
+
+    if (!controller) return () => abortController.abort();
+    if (!activeTrack || !library.settings.playback.normalizeVolume || isLoadingTrack) {
+      controller.setNormalizationGain(1, activeTrack && !isLoadingTrack ? 160 : 0);
+      return () => abortController.abort();
+    }
+
+    controller.setNormalizationGain(1);
+    void (async () => {
+      const cachedGain = await getCachedTrackNormalizationGain(activeTrack);
+      if (abortController.signal.aborted) return;
+      if (cachedGain !== null) {
+        controller.setNormalizationGain(cachedGain, 160);
+        return;
+      }
+
+      const gain = await analyzeTrackNormalizationGain(activeTrack, abortController.signal);
+      if (abortController.signal.aborted) return;
+      controller.setNormalizationGain(gain, 240);
+    })();
+
+    return () => abortController.abort();
+  }, [activeTrack, isLoadingTrack, library.settings.playback.normalizeVolume]);
 
   const selectTrackInList = useCallback(
     (track: LibraryTrack, event?: React.MouseEvent<HTMLDivElement>) => {
@@ -2206,19 +2248,16 @@ export function App() {
     if (selectedTrack) void selectTrack(selectedTrack, true, 0, true, "source");
   }, [allPlayableTracksById, selectTrack, selectedTrackIds]);
 
-  const selectLibrarySource = useCallback(
-    (source: LibraryState["selectedSource"]) => {
-      setSelectedLibraryBrowserItemIds([]);
-      libraryBrowserSelectionAnchorIdRef.current = null;
-      setLibrary((current) => {
-        const nextState = { ...current, selectedSource: source };
-        libraryRef.current = nextState;
-        void window.playhead.saveLibrarySelectedSource(source);
-        return nextState;
-      });
-    },
-    [],
-  );
+  const selectLibrarySource = useCallback((source: LibraryState["selectedSource"]) => {
+    setSelectedLibraryBrowserItemIds([]);
+    libraryBrowserSelectionAnchorIdRef.current = null;
+    setLibrary((current) => {
+      const nextState = { ...current, selectedSource: source };
+      libraryRef.current = nextState;
+      void window.playhead.saveLibrarySelectedSource(source);
+      return nextState;
+    });
+  }, []);
 
   const selectSoundCloudSource = useCallback(
     async (collectionId: string) => {
@@ -2587,7 +2626,9 @@ export function App() {
         .then((scanned) => {
           const latest = libraryRef.current;
           const scannedState = mergeScannedFolder(latest, scanned);
-          return persistLibrary(mergeScannedLibraryState(latest, scannedState, [scanned.folder.id]));
+          return persistLibrary(
+            mergeScannedLibraryState(latest, scannedState, [scanned.folder.id]),
+          );
         })
         .catch((error) => setError(getErrorMessage(error, "Could not rescan changed folder.")));
     });
@@ -2672,9 +2713,8 @@ export function App() {
       dragToSeek: true,
       sampleRate: 16000,
     });
-    wavesurfer.setVolume(volumeRef.current);
-
     wavesurferRef.current = wavesurfer;
+    volumeControllerRef.current?.setBaseVolume(volumeRef.current);
     setIsWaveformEngineReady(true);
     const unsubscribers = [
       wavesurfer.on("ready", (nextDuration) => {

--- a/src/renderer/src/features/audio/__tests__/audio-analysis.test.ts
+++ b/src/renderer/src/features/audio/__tests__/audio-analysis.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildWaveformCachePeaks,
+  estimateIntegratedLoudnessDb,
+  getLoudnessNormalizationGain,
   getWaveformAnalysisPeakCount,
   shouldAnalyzeTrackBpm,
 } from "../audio-analysis";
@@ -41,6 +43,26 @@ describe("shouldAnalyzeTrackBpm", () => {
 
   it("allows analyzed bpm to be revalidated from cache", () => {
     expect(shouldAnalyzeTrackBpm(createTrack({ bpm: 128, bpmSource: "analysis" }))).toBe(true);
+  });
+});
+
+describe("volume normalization", () => {
+  it("estimates steady-state loudness from decoded audio", () => {
+    const samples = Array.from({ length: 16000 }, () => 0.1);
+    const loudnessDb = estimateIntegratedLoudnessDb(createBuffer(samples, 16000));
+    expect(loudnessDb).not.toBeNull();
+    expect(loudnessDb!).toBeCloseTo(-20.691, 2);
+  });
+
+  it("targets -14 dB while clamping extreme gain changes", () => {
+    expect(getLoudnessNormalizationGain(-20)).toBeCloseTo(10 ** (6 / 20), 5);
+    expect(getLoudnessNormalizationGain(-8)).toBeCloseTo(10 ** (-6 / 20), 5);
+    expect(getLoudnessNormalizationGain(-40)).toBeCloseTo(10 ** (6 / 20), 5);
+    expect(getLoudnessNormalizationGain(4)).toBeCloseTo(10 ** (-12 / 20), 5);
+  });
+
+  it("ignores silence", () => {
+    expect(estimateIntegratedLoudnessDb(createBuffer([0, 0, 0], 3))).toBeNull();
   });
 });
 

--- a/src/renderer/src/features/audio/__tests__/audio-analysis.test.ts
+++ b/src/renderer/src/features/audio/__tests__/audio-analysis.test.ts
@@ -31,6 +31,24 @@ function createBuffer(samples: number[], sampleRate = 1): AudioBuffer {
   } as unknown as AudioBuffer;
 }
 
+function createSineBuffer({
+  frequency,
+  sampleRate,
+  duration,
+  amplitude = 1,
+}: {
+  frequency: number;
+  sampleRate: number;
+  duration: number;
+  amplitude?: number;
+}): AudioBuffer {
+  const samples = Array.from(
+    { length: sampleRate * duration },
+    (_, index) => amplitude * Math.sin((2 * Math.PI * frequency * index) / sampleRate),
+  );
+  return createBuffer(samples, sampleRate);
+}
+
 describe("shouldAnalyzeTrackBpm", () => {
   it("includes tracks without bpm", () => {
     expect(shouldAnalyzeTrackBpm(createTrack())).toBe(true);
@@ -47,11 +65,11 @@ describe("shouldAnalyzeTrackBpm", () => {
 });
 
 describe("volume normalization", () => {
-  it("estimates steady-state loudness from decoded audio", () => {
-    const samples = Array.from({ length: 16000 }, () => 0.1);
-    const loudnessDb = estimateIntegratedLoudnessDb(createBuffer(samples, 16000));
-    expect(loudnessDb).not.toBeNull();
-    expect(loudnessDb!).toBeCloseTo(-20.691, 2);
+  it.each([16_000, 48_000])("matches the BS.1770 reference level at %i Hz", (sampleRate) => {
+    const loudnessDb = estimateIntegratedLoudnessDb(
+      createSineBuffer({ frequency: 997, sampleRate, duration: 1 }),
+    );
+    expect(loudnessDb).toBeCloseTo(-3.01, 1);
   });
 
   it("attenuates toward -18 dB without boosting quiet tracks", () => {

--- a/src/renderer/src/features/audio/__tests__/audio-analysis.test.ts
+++ b/src/renderer/src/features/audio/__tests__/audio-analysis.test.ts
@@ -54,10 +54,10 @@ describe("volume normalization", () => {
     expect(loudnessDb!).toBeCloseTo(-20.691, 2);
   });
 
-  it("targets -14 dB while clamping extreme gain changes", () => {
-    expect(getLoudnessNormalizationGain(-20)).toBeCloseTo(10 ** (6 / 20), 5);
-    expect(getLoudnessNormalizationGain(-8)).toBeCloseTo(10 ** (-6 / 20), 5);
-    expect(getLoudnessNormalizationGain(-40)).toBeCloseTo(10 ** (6 / 20), 5);
+  it("attenuates toward -18 dB without boosting quiet tracks", () => {
+    expect(getLoudnessNormalizationGain(-20)).toBe(1);
+    expect(getLoudnessNormalizationGain(-8)).toBeCloseTo(10 ** (-10 / 20), 5);
+    expect(getLoudnessNormalizationGain(-40)).toBe(1);
     expect(getLoudnessNormalizationGain(4)).toBeCloseTo(10 ** (-12 / 20), 5);
   });
 

--- a/src/renderer/src/features/audio/__tests__/playback-volume.test.ts
+++ b/src/renderer/src/features/audio/__tests__/playback-volume.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { PlaybackVolumeController, type VolumeAnimationScheduler } from "../playback-volume";
+
+function createScheduler(): VolumeAnimationScheduler & { advanceTo: (time: number) => void } {
+  let now = 0;
+  let nextId = 0;
+  const frames = new Map<number, () => void>();
+
+  return {
+    now: () => now,
+    requestFrame: (callback) => {
+      nextId += 1;
+      frames.set(nextId, callback);
+      return nextId;
+    },
+    cancelFrame: (id) => {
+      frames.delete(id);
+    },
+    advanceTo: (time) => {
+      now = time;
+      const callbacks = [...frames.values()];
+      frames.clear();
+      callbacks.forEach((callback) => callback());
+    },
+  };
+}
+
+describe("PlaybackVolumeController", () => {
+  it("adjusts the user's base volume without compounding normalization gain", () => {
+    const outputs: number[] = [];
+    const controller = new PlaybackVolumeController((volume) => outputs.push(volume));
+
+    controller.setBaseVolume(0.8);
+    controller.setNormalizationGain(0.5);
+    controller.adjustBaseVolume(0.05);
+
+    expect(controller.getBaseVolume()).toBeCloseTo(0.85);
+    expect(outputs.at(-1)).toBeCloseTo(0.425);
+  });
+
+  it("ramps an uncached gain change instead of applying an abrupt drop", () => {
+    const outputs: number[] = [];
+    const scheduler = createScheduler();
+    const controller = new PlaybackVolumeController((volume) => outputs.push(volume), scheduler);
+
+    controller.setBaseVolume(1);
+    controller.setNormalizationGain(0.5, 200);
+    expect(outputs.at(-1)).toBe(1);
+
+    scheduler.advanceTo(100);
+    expect(outputs.at(-1)).toBeCloseTo(0.75);
+
+    scheduler.advanceTo(200);
+    expect(outputs.at(-1)).toBeCloseTo(0.5);
+  });
+
+  it("restores the user's base volume when normalization is disabled", () => {
+    const outputs: number[] = [];
+    const controller = new PlaybackVolumeController((volume) => outputs.push(volume));
+
+    controller.setBaseVolume(0.8);
+    controller.setNormalizationGain(0.5);
+    controller.setNormalizationGain(1);
+
+    expect(outputs.at(-1)).toBeCloseTo(0.8);
+  });
+});

--- a/src/renderer/src/features/audio/__tests__/volume-normalization.test.ts
+++ b/src/renderer/src/features/audio/__tests__/volume-normalization.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import type { LibraryTrack } from "../../../../../shared/library";
+import { buildTrackNormalizationCacheKey } from "../volume-normalization";
+
+const track: LibraryTrack = {
+  id: "track-1",
+  path: "/music/track.mp3",
+  fileName: "track.mp3",
+  title: "Track",
+  artist: "Artist",
+  duration: 180,
+  folderId: "folder-1",
+};
+
+describe("volume normalization cache", () => {
+  it("invalidates a local result when the source file changes", () => {
+    const original = buildTrackNormalizationCacheKey(track, { size: 1_000, mtimeMs: 100 });
+    const replaced = buildTrackNormalizationCacheKey(track, { size: 1_200, mtimeMs: 200 });
+
+    expect(replaced).not.toBe(original);
+  });
+});

--- a/src/renderer/src/features/audio/audio-analysis.ts
+++ b/src/renderer/src/features/audio/audio-analysis.ts
@@ -1,4 +1,3 @@
-import { analyze } from "web-audio-beat-detector";
 import type { LibraryTrack } from "../../../../shared/library";
 
 export const waveformAnalysisPeakRate = 20;
@@ -38,6 +37,7 @@ export async function analyzeBpmFromBuffer(buffer: AudioBuffer): Promise<{
   bpm: number;
   tempo: number;
 }> {
+  const { analyze } = await import("web-audio-beat-detector");
   const tempo = await analyze(buffer);
   const bpm = Math.round(tempo);
   if (!Number.isFinite(bpm) || bpm <= 0) throw new Error("BPM could not be detected.");
@@ -52,41 +52,118 @@ function average(values: number[]): number {
   return values.reduce((sum, value) => sum + value, 0) / values.length;
 }
 
+type BiquadCoefficients = {
+  b0: number;
+  b1: number;
+  b2: number;
+  a1: number;
+  a2: number;
+};
+
+function createDeManHighShelf(sampleRate: number): BiquadCoefficients {
+  const gainDb = 3.99984385397;
+  const quality = 0.7071752369554193;
+  const frequency = 1681.9744509555319;
+  const k = Math.tan((Math.PI * frequency) / sampleRate);
+  const highGain = 10 ** (gainDb / 20);
+  const bandGain = highGain ** 0.499666774155;
+  const denominator = 1 + k / quality + k * k;
+
+  return {
+    b0: (highGain + (bandGain * k) / quality + k * k) / denominator,
+    b1: (2 * (k * k - highGain)) / denominator,
+    b2: (highGain - (bandGain * k) / quality + k * k) / denominator,
+    a1: (2 * (k * k - 1)) / denominator,
+    a2: (1 - k / quality + k * k) / denominator,
+  };
+}
+
+function createDeManHighPass(sampleRate: number): BiquadCoefficients {
+  const quality = 0.5003270373253953;
+  const frequency = 38.13547087613982;
+  const k = Math.tan((Math.PI * frequency) / sampleRate);
+  const denominator = 1 + k / quality + k * k;
+
+  return {
+    b0: 1,
+    b1: -2,
+    b2: 1,
+    a1: (2 * (k * k - 1)) / denominator,
+    a2: (1 - k / quality + k * k) / denominator,
+  };
+}
+
+function createBiquad(coefficients: BiquadCoefficients): (sample: number) => number {
+  let input1 = 0;
+  let input2 = 0;
+  let output1 = 0;
+  let output2 = 0;
+
+  return (sample) => {
+    const output =
+      coefficients.b0 * sample +
+      coefficients.b1 * input1 +
+      coefficients.b2 * input2 -
+      coefficients.a1 * output1 -
+      coefficients.a2 * output2;
+    input2 = input1;
+    input1 = sample;
+    output2 = output1;
+    output1 = output;
+    return output;
+  };
+}
+
+function getBs1770ChannelWeights(channelCount: number): number[] {
+  if (channelCount === 4) return [1, 1, 1.41, 1.41];
+  if (channelCount === 5) return [1, 1, 1, 1.41, 1.41];
+  if (channelCount === 6) return [1, 1, 1, 0, 1.41, 1.41];
+  if (channelCount === 7) return [1, 1, 1, 0, 1.41, 1.41, 1.41];
+  if (channelCount === 8) return [1, 1, 1, 0, 1.41, 1.41, 1.41, 1.41];
+  return Array.from({ length: channelCount }, () => 1);
+}
+
 export function estimateIntegratedLoudnessDb(buffer: AudioBuffer): number | null {
   if (!buffer.numberOfChannels || !buffer.length || !buffer.sampleRate) return null;
 
   const channels = Array.from({ length: buffer.numberOfChannels }, (_, index) =>
     buffer.getChannelData(index),
   );
-  const blockLength = Math.max(1, Math.round(buffer.sampleRate * 0.4));
   const stepLength = Math.max(1, Math.round(buffer.sampleRate * 0.1));
+  const blockLength = stepLength * 4;
+  if (buffer.length < blockLength) return null;
+  const segmentCount = Math.ceil(buffer.length / stepLength);
+  const segmentEnergies = new Float64Array(segmentCount);
+  const channelWeights = getBs1770ChannelWeights(buffer.numberOfChannels);
+
+  for (let channelIndex = 0; channelIndex < channels.length; channelIndex += 1) {
+    const highShelf = createBiquad(createDeManHighShelf(buffer.sampleRate));
+    const highPass = createBiquad(createDeManHighPass(buffer.sampleRate));
+    const channel = channels[channelIndex];
+    const channelWeight = channelWeights[channelIndex] ?? 1;
+
+    for (let sampleIndex = 0; sampleIndex < buffer.length; sampleIndex += 1) {
+      const weightedSample = highPass(highShelf(channel[sampleIndex] ?? 0));
+      const segmentIndex = Math.floor(sampleIndex / stepLength);
+      segmentEnergies[segmentIndex] += channelWeight * weightedSample * weightedSample;
+    }
+  }
+
   const blockEnergies: number[] = [];
 
-  const measureBlock = (start: number, end: number) => {
+  for (let start = 0; start + blockLength <= buffer.length; start += stepLength) {
+    const firstSegment = Math.floor(start / stepLength);
     let energy = 0;
-    let frames = 0;
-
-    for (let sampleIndex = start; sampleIndex < end; sampleIndex += 1) {
-      let frameEnergy = 0;
-      for (const channel of channels) {
-        const sample = channel[sampleIndex] ?? 0;
-        frameEnergy += sample * sample;
-      }
-      energy += frameEnergy / channels.length;
-      frames += 1;
+    for (let offset = 0; offset < 4; offset += 1) {
+      energy += segmentEnergies[firstSegment + offset] ?? 0;
     }
-
-    if (frames === 0) return;
-    const meanSquare = energy / frames;
-    if (meanSquare <= 0 || !Number.isFinite(meanSquare)) return;
-    if (energyToLoudnessDb(meanSquare) >= loudnessAbsoluteGateDb) blockEnergies.push(meanSquare);
-  };
-
-  if (buffer.length <= blockLength) {
-    measureBlock(0, buffer.length);
-  } else {
-    for (let start = 0; start + blockLength <= buffer.length; start += stepLength) {
-      measureBlock(start, start + blockLength);
+    const meanSquare = energy / blockLength;
+    if (
+      meanSquare > 0 &&
+      Number.isFinite(meanSquare) &&
+      energyToLoudnessDb(meanSquare) >= loudnessAbsoluteGateDb
+    ) {
+      blockEnergies.push(meanSquare);
     }
   }
 

--- a/src/renderer/src/features/audio/audio-analysis.ts
+++ b/src/renderer/src/features/audio/audio-analysis.ts
@@ -3,6 +3,13 @@ import type { LibraryTrack } from "../../../../shared/library";
 
 export const waveformAnalysisPeakRate = 20;
 export const waveformAnalysisMaxPeaks = 24_000;
+export const volumeNormalizationTargetLoudnessDb = -14;
+
+const loudnessAbsoluteGateDb = -70;
+const loudnessOffsetDb = -0.691;
+const loudnessRelativeGateDb = 10;
+const volumeNormalizationMinGainDb = -12;
+const volumeNormalizationMaxGainDb = 6;
 
 export function shouldAnalyzeTrackBpm(track: LibraryTrack): boolean {
   if (!track.bpm) return true;
@@ -35,6 +42,81 @@ export async function analyzeBpmFromBuffer(buffer: AudioBuffer): Promise<{
   const bpm = Math.round(tempo);
   if (!Number.isFinite(bpm) || bpm <= 0) throw new Error("BPM could not be detected.");
   return { bpm, tempo };
+}
+
+function energyToLoudnessDb(energy: number): number {
+  return loudnessOffsetDb + 10 * Math.log10(energy);
+}
+
+function average(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function estimateIntegratedLoudnessDb(buffer: AudioBuffer): number | null {
+  if (!buffer.numberOfChannels || !buffer.length || !buffer.sampleRate) return null;
+
+  const channels = Array.from({ length: buffer.numberOfChannels }, (_, index) =>
+    buffer.getChannelData(index),
+  );
+  const blockLength = Math.max(1, Math.round(buffer.sampleRate * 0.4));
+  const stepLength = Math.max(1, Math.round(buffer.sampleRate * 0.1));
+  const blockEnergies: number[] = [];
+
+  const measureBlock = (start: number, end: number) => {
+    let energy = 0;
+    let frames = 0;
+
+    for (let sampleIndex = start; sampleIndex < end; sampleIndex += 1) {
+      let frameEnergy = 0;
+      for (const channel of channels) {
+        const sample = channel[sampleIndex] ?? 0;
+        frameEnergy += sample * sample;
+      }
+      energy += frameEnergy / channels.length;
+      frames += 1;
+    }
+
+    if (frames === 0) return;
+    const meanSquare = energy / frames;
+    if (meanSquare <= 0 || !Number.isFinite(meanSquare)) return;
+    if (energyToLoudnessDb(meanSquare) >= loudnessAbsoluteGateDb) blockEnergies.push(meanSquare);
+  };
+
+  if (buffer.length <= blockLength) {
+    measureBlock(0, buffer.length);
+  } else {
+    for (let start = 0; start + blockLength <= buffer.length; start += stepLength) {
+      measureBlock(start, start + blockLength);
+    }
+  }
+
+  if (blockEnergies.length === 0) return null;
+
+  const ungatedLoudnessDb = energyToLoudnessDb(average(blockEnergies));
+  const relativeGateDb = Math.max(
+    loudnessAbsoluteGateDb,
+    ungatedLoudnessDb - loudnessRelativeGateDb,
+  );
+  const gatedEnergies = blockEnergies.filter(
+    (energy) => energyToLoudnessDb(energy) >= relativeGateDb,
+  );
+  if (gatedEnergies.length === 0) return null;
+
+  const loudnessDb = energyToLoudnessDb(average(gatedEnergies));
+  return Number.isFinite(loudnessDb) ? loudnessDb : null;
+}
+
+export function getLoudnessNormalizationGain(
+  loudnessDb: number,
+  targetLoudnessDb = volumeNormalizationTargetLoudnessDb,
+): number {
+  if (!Number.isFinite(loudnessDb) || !Number.isFinite(targetLoudnessDb)) return 1;
+
+  const gainDb = Math.min(
+    volumeNormalizationMaxGainDb,
+    Math.max(volumeNormalizationMinGainDb, targetLoudnessDb - loudnessDb),
+  );
+  return 10 ** (gainDb / 20);
 }
 
 export function getWaveformAnalysisPeakCount(duration: number): number {

--- a/src/renderer/src/features/audio/audio-analysis.ts
+++ b/src/renderer/src/features/audio/audio-analysis.ts
@@ -3,13 +3,13 @@ import type { LibraryTrack } from "../../../../shared/library";
 
 export const waveformAnalysisPeakRate = 20;
 export const waveformAnalysisMaxPeaks = 24_000;
-export const volumeNormalizationTargetLoudnessDb = -14;
+export const volumeNormalizationTargetLoudnessDb = -18;
 
 const loudnessAbsoluteGateDb = -70;
 const loudnessOffsetDb = -0.691;
 const loudnessRelativeGateDb = 10;
 const volumeNormalizationMinGainDb = -12;
-const volumeNormalizationMaxGainDb = 6;
+const volumeNormalizationMaxGainDb = 0;
 
 export function shouldAnalyzeTrackBpm(track: LibraryTrack): boolean {
   if (!track.bpm) return true;

--- a/src/renderer/src/features/audio/loudness-analysis.worker.ts
+++ b/src/renderer/src/features/audio/loudness-analysis.worker.ts
@@ -1,0 +1,23 @@
+/// <reference lib="webworker" />
+
+import { estimateIntegratedLoudnessDb } from "./audio-analysis";
+
+type LoudnessAnalysisRequest = {
+  channels: Float32Array[];
+  sampleRate: number;
+};
+
+self.onmessage = (event: MessageEvent<LoudnessAnalysisRequest>) => {
+  const { channels, sampleRate } = event.data;
+  const buffer = {
+    numberOfChannels: channels.length,
+    length: channels[0]?.length ?? 0,
+    duration: channels[0]?.length ? channels[0].length / sampleRate : 0,
+    sampleRate,
+    getChannelData: (channel: number) => channels[channel],
+  } as AudioBuffer;
+
+  self.postMessage(estimateIntegratedLoudnessDb(buffer));
+};
+
+export {};

--- a/src/renderer/src/features/audio/loudness-worker-client.ts
+++ b/src/renderer/src/features/audio/loudness-worker-client.ts
@@ -1,0 +1,36 @@
+export function analyzeLoudnessOffThread(
+  buffer: AudioBuffer,
+  signal?: AbortSignal,
+): Promise<number | null> {
+  if (signal?.aborted) return Promise.reject(new DOMException("Analysis aborted", "AbortError"));
+
+  const worker = new Worker(new URL("./loudness-analysis.worker.ts", import.meta.url), {
+    type: "module",
+  });
+  const channels = Array.from({ length: buffer.numberOfChannels }, (_, channel) =>
+    buffer.getChannelData(channel).slice(),
+  );
+  const transfer = channels.map((channel) => channel.buffer);
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      signal?.removeEventListener("abort", handleAbort);
+      worker.terminate();
+    };
+    const handleAbort = () => {
+      cleanup();
+      reject(new DOMException("Analysis aborted", "AbortError"));
+    };
+
+    worker.onmessage = (event: MessageEvent<number | null>) => {
+      cleanup();
+      resolve(event.data);
+    };
+    worker.onerror = (event) => {
+      cleanup();
+      reject(event.error || new Error(event.message || "Loudness analysis failed"));
+    };
+    signal?.addEventListener("abort", handleAbort, { once: true });
+    worker.postMessage({ channels, sampleRate: buffer.sampleRate }, transfer);
+  });
+}

--- a/src/renderer/src/features/audio/playback-volume.ts
+++ b/src/renderer/src/features/audio/playback-volume.ts
@@ -1,0 +1,77 @@
+export type VolumeAnimationScheduler = {
+  now: () => number;
+  requestFrame: (callback: () => void) => number;
+  cancelFrame: (id: number) => void;
+};
+
+const browserScheduler: VolumeAnimationScheduler = {
+  now: () => performance.now(),
+  requestFrame: (callback) => requestAnimationFrame(callback),
+  cancelFrame: (id) => cancelAnimationFrame(id),
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export class PlaybackVolumeController {
+  private baseVolume = 1;
+  private normalizationGain = 1;
+  private animationFrame: number | null = null;
+
+  constructor(
+    private readonly writeVolume: (volume: number) => void,
+    private readonly scheduler = browserScheduler,
+  ) {}
+
+  getBaseVolume(): number {
+    return this.baseVolume;
+  }
+
+  setBaseVolume(volume: number): number {
+    this.baseVolume = Number.isFinite(volume) ? clamp(volume, 0, 1) : 1;
+    this.applyVolume();
+    return this.baseVolume;
+  }
+
+  adjustBaseVolume(offset: number): number {
+    return this.setBaseVolume(this.baseVolume + offset);
+  }
+
+  setNormalizationGain(gain: number, rampDurationMs = 0): void {
+    const nextGain = Number.isFinite(gain) ? clamp(gain, 0.25, 1) : 1;
+    this.cancelRamp();
+
+    if (rampDurationMs <= 0 || nextGain === this.normalizationGain) {
+      this.normalizationGain = nextGain;
+      this.applyVolume();
+      return;
+    }
+
+    const initialGain = this.normalizationGain;
+    const startedAt = this.scheduler.now();
+    const update = () => {
+      const progress = clamp((this.scheduler.now() - startedAt) / rampDurationMs, 0, 1);
+      this.normalizationGain = initialGain + (nextGain - initialGain) * progress;
+      this.applyVolume();
+      if (progress < 1) this.animationFrame = this.scheduler.requestFrame(update);
+      else this.animationFrame = null;
+    };
+
+    this.animationFrame = this.scheduler.requestFrame(update);
+  }
+
+  dispose(): void {
+    this.cancelRamp();
+  }
+
+  private applyVolume(): void {
+    this.writeVolume(clamp(this.baseVolume * this.normalizationGain, 0, 1));
+  }
+
+  private cancelRamp(): void {
+    if (this.animationFrame === null) return;
+    this.scheduler.cancelFrame(this.animationFrame);
+    this.animationFrame = null;
+  }
+}

--- a/src/renderer/src/features/audio/volume-normalization.ts
+++ b/src/renderer/src/features/audio/volume-normalization.ts
@@ -1,13 +1,8 @@
-import WaveSurfer from "wavesurfer.js";
-import type { LibraryTrack } from "../../../../shared/library";
-import {
-  decodeAudioBytes,
-  decodeAudioTrack,
-  estimateIntegratedLoudnessDb,
-  getLoudnessNormalizationGain,
-} from "./audio-analysis";
+import type { AudioFileRevision, LibraryTrack } from "../../../../shared/library";
+import { decodeAudioBytes, decodeAudioTrack, getLoudnessNormalizationGain } from "./audio-analysis";
+import { analyzeLoudnessOffThread } from "./loudness-worker-client";
 
-const normalizationCacheStorageKey = "playhead:volume-normalization-cache:v1";
+const normalizationCacheStorageKey = "playhead:volume-normalization-cache:v2";
 const normalizationCacheLimit = 2_000;
 
 type CachedNormalization = {
@@ -18,77 +13,8 @@ type CachedNormalization = {
 
 type NormalizationCache = Record<string, CachedNormalization>;
 
-type VolumeNormalizationRuntime = {
-  patched: boolean;
-  activeWaveSurfer: WaveSurfer | null;
-  baseVolume: number;
-  gain: number;
-  rawSetVolume: ((waveSurfer: WaveSurfer, volume: number) => void) | null;
-  activeTrack: LibraryTrack | null;
-  requestId: number;
-};
-
-const globalScope = globalThis as typeof globalThis & {
-  __playheadVolumeNormalizationRuntime?: VolumeNormalizationRuntime;
-};
-const runtime =
-  globalScope.__playheadVolumeNormalizationRuntime ||
-  (globalScope.__playheadVolumeNormalizationRuntime = {
-    patched: false,
-    activeWaveSurfer: null,
-    baseVolume: 1,
-    gain: 1,
-    rawSetVolume: null,
-    activeTrack: null,
-    requestId: 0,
-  });
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-function applyRuntimeGain(): void {
-  const waveSurfer = runtime.activeWaveSurfer;
-  if (!waveSurfer || !runtime.rawSetVolume) return;
-  runtime.rawSetVolume(waveSurfer, clamp(runtime.baseVolume * runtime.gain, 0, 1));
-}
-
-if (!runtime.patched) {
-  const rawCreate = WaveSurfer.create.bind(WaveSurfer);
-  const rawSetVolume = WaveSurfer.prototype.setVolume;
-  const rawDestroy = WaveSurfer.prototype.destroy;
-
-  runtime.rawSetVolume = (waveSurfer, volume) => rawSetVolume.call(waveSurfer, volume);
-
-  WaveSurfer.create = ((options: Parameters<typeof WaveSurfer.create>[0]) => {
-    const waveSurfer = rawCreate(options);
-    runtime.activeWaveSurfer = waveSurfer;
-    runtime.baseVolume = 1;
-    runtime.gain = 1;
-    return waveSurfer;
-  }) as typeof WaveSurfer.create;
-
-  WaveSurfer.prototype.setVolume = function setVolumeWithNormalization(volume: number) {
-    runtime.activeWaveSurfer = this;
-    runtime.baseVolume = clamp(volume, 0, 1);
-    applyRuntimeGain();
-  };
-
-  WaveSurfer.prototype.destroy = function destroyWithNormalizationCleanup() {
-    if (runtime.activeWaveSurfer === this) {
-      runtime.activeWaveSurfer = null;
-      runtime.activeTrack = null;
-      runtime.baseVolume = 1;
-      runtime.gain = 1;
-    }
-    return rawDestroy.call(this);
-  };
-
-  runtime.patched = true;
-}
-
 let normalizationCache: NormalizationCache | null = null;
-const analysisPromises = new Map<string, Promise<number>>();
+let analysisQueue: Promise<void> = Promise.resolve();
 
 function getNormalizationCache(): NormalizationCache {
   if (normalizationCache) return normalizationCache;
@@ -107,7 +33,10 @@ function getNormalizationCache(): NormalizationCache {
   return normalizationCache;
 }
 
-function getTrackCacheKey(track: LibraryTrack): string {
+export function buildTrackNormalizationCacheKey(
+  track: LibraryTrack,
+  revision: AudioFileRevision | null,
+): string {
   const sourceKey = track.soundcloud
     ? `soundcloud:${track.soundcloud.id}`
     : `${track.source || "local"}:${track.id}`;
@@ -117,14 +46,26 @@ function getTrackCacheKey(track: LibraryTrack): string {
     track.fileName,
     track.sampleRate || 0,
     track.bitRate || 0,
+    revision ? Math.trunc(revision.size) : "remote",
+    revision ? Math.trunc(revision.mtimeMs) : "remote",
   ].join("|");
 }
 
-function saveNormalizationCacheEntry(
-  cacheKey: string,
-  loudnessDb: number,
-  gain: number,
-): void {
+async function resolveTrackCacheKey(track: LibraryTrack): Promise<string | null> {
+  if (track.source === "soundcloud" || track.soundcloud) {
+    return buildTrackNormalizationCacheKey(track, null);
+  }
+
+  try {
+    const revision = await window.playhead.getAudioFileRevision(track.path);
+    return buildTrackNormalizationCacheKey(track, revision);
+  } catch (error) {
+    console.warn("Could not read audio file revision", { path: track.path, error });
+    return null;
+  }
+}
+
+function saveNormalizationCacheEntry(cacheKey: string, loudnessDb: number, gain: number): void {
   const cache = getNormalizationCache();
   cache[cacheKey] = { gain, loudnessDb, analyzedAt: Date.now() };
 
@@ -161,75 +102,59 @@ async function decodeTrackForNormalization(track: LibraryTrack): Promise<AudioBu
   return decodeAudioTrack(track, window.playhead.readAudioFile);
 }
 
-function setPlaybackNormalizationGain(gain: number): void {
-  runtime.gain = Number.isFinite(gain) ? clamp(gain, 0.25, 1) : 1;
-  applyRuntimeGain();
+function enqueueAnalysis<T>(task: () => Promise<T>): Promise<T> {
+  const result = analysisQueue.then(task, task);
+  analysisQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
 }
 
-export function getCachedTrackNormalizationGain(track: LibraryTrack): number | null {
-  const cached = getNormalizationCache()[getTrackCacheKey(track)];
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+export async function getCachedTrackNormalizationGain(track: LibraryTrack): Promise<number | null> {
+  const cacheKey = await resolveTrackCacheKey(track);
+  if (!cacheKey) return null;
+  const cached = getNormalizationCache()[cacheKey];
   return cached && Number.isFinite(cached.gain) ? cached.gain : null;
 }
 
-export function analyzeTrackNormalizationGain(track: LibraryTrack): Promise<number> {
-  const cacheKey = getTrackCacheKey(track);
-  const cached = getNormalizationCache()[cacheKey];
-  if (cached && Number.isFinite(cached.gain)) return Promise.resolve(cached.gain);
+export async function analyzeTrackNormalizationGain(
+  track: LibraryTrack,
+  signal?: AbortSignal,
+): Promise<number> {
+  const cacheKey = await resolveTrackCacheKey(track);
+  if (signal?.aborted) return 1;
+  if (cacheKey) {
+    const cached = getNormalizationCache()[cacheKey];
+    if (cached && Number.isFinite(cached.gain)) return cached.gain;
+  }
 
-  const pending = analysisPromises.get(cacheKey);
-  if (pending) return pending;
+  return enqueueAnalysis(async () => {
+    if (signal?.aborted) return 1;
+    if (cacheKey) {
+      const cached = getNormalizationCache()[cacheKey];
+      if (cached && Number.isFinite(cached.gain)) return cached.gain;
+    }
 
-  const analysis = (async () => {
     try {
       const buffer = await decodeTrackForNormalization(track);
-      if (!buffer) return 1;
+      if (!buffer || signal?.aborted) return 1;
 
-      const loudnessDb = estimateIntegratedLoudnessDb(buffer);
-      if (loudnessDb === null) return 1;
+      const loudnessDb = await analyzeLoudnessOffThread(buffer, signal);
+      if (loudnessDb === null || signal?.aborted) return 1;
 
       const gain = getLoudnessNormalizationGain(loudnessDb);
-      saveNormalizationCacheEntry(cacheKey, loudnessDb, gain);
+      if (cacheKey) saveNormalizationCacheEntry(cacheKey, loudnessDb, gain);
       return gain;
     } catch (error) {
-      console.warn("Failed to analyze track loudness", { path: track.path, error });
+      if (!isAbortError(error)) {
+        console.warn("Failed to analyze track loudness", { path: track.path, error });
+      }
       return 1;
-    } finally {
-      analysisPromises.delete(cacheKey);
     }
-  })();
-
-  analysisPromises.set(cacheKey, analysis);
-  return analysis;
-}
-
-export async function applyTrackVolumeNormalization(track: LibraryTrack | null): Promise<void> {
-  const requestId = runtime.requestId + 1;
-  runtime.requestId = requestId;
-  runtime.activeTrack = track;
-
-  if (!track) {
-    setPlaybackNormalizationGain(1);
-    return;
-  }
-
-  let enabled = false;
-  try {
-    const library = await window.playhead.getLibraryState();
-    enabled = library.settings.playback.normalizeVolume;
-  } catch (error) {
-    console.warn("Could not read volume normalization setting", error);
-  }
-
-  if (requestId !== runtime.requestId || runtime.activeTrack?.id !== track.id) return;
-  if (!enabled) {
-    setPlaybackNormalizationGain(1);
-    return;
-  }
-
-  const cachedGain = getCachedTrackNormalizationGain(track);
-  setPlaybackNormalizationGain(cachedGain ?? 1);
-
-  const gain = await analyzeTrackNormalizationGain(track);
-  if (requestId !== runtime.requestId || runtime.activeTrack?.id !== track.id) return;
-  setPlaybackNormalizationGain(gain);
+  });
 }

--- a/src/renderer/src/features/audio/volume-normalization.ts
+++ b/src/renderer/src/features/audio/volume-normalization.ts
@@ -18,20 +18,12 @@ type CachedNormalization = {
 
 type NormalizationCache = Record<string, CachedNormalization>;
 
-type AudioGraph = {
-  context: AudioContext;
-  gain: GainNode;
-  limiter: DynamicsCompressorNode;
-};
-
 type VolumeNormalizationRuntime = {
   patched: boolean;
   activeWaveSurfer: WaveSurfer | null;
   baseVolume: number;
   gain: number;
-  useWebAudioGain: boolean;
   rawSetVolume: ((waveSurfer: WaveSurfer, volume: number) => void) | null;
-  graphs: WeakMap<HTMLMediaElement, AudioGraph>;
   activeTrack: LibraryTrack | null;
   requestId: number;
 };
@@ -46,9 +38,7 @@ const runtime =
     activeWaveSurfer: null,
     baseVolume: 1,
     gain: 1,
-    useWebAudioGain: false,
     rawSetVolume: null,
-    graphs: new WeakMap<HTMLMediaElement, AudioGraph>(),
     activeTrack: null,
     requestId: 0,
   });
@@ -57,54 +47,10 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function getFallbackVolume(baseVolume: number, gain: number): number {
-  return clamp(baseVolume * Math.min(gain, 1), 0, 1);
-}
-
-function configureLimiter(limiter: DynamicsCompressorNode): void {
-  limiter.threshold.value = -1;
-  limiter.knee.value = 0;
-  limiter.ratio.value = 20;
-  limiter.attack.value = 0.003;
-  limiter.release.value = 0.1;
-}
-
-function ensureAudioGraph(waveSurfer: WaveSurfer): AudioGraph | null {
-  const media = waveSurfer.getMediaElement();
-  const existing = runtime.graphs.get(media);
-  if (existing) return existing;
-
-  try {
-    const context = new AudioContext();
-    const source = context.createMediaElementSource(media);
-    const gain = context.createGain();
-    const limiter = context.createDynamicsCompressor();
-    configureLimiter(limiter);
-    source.connect(gain).connect(limiter).connect(context.destination);
-    const graph = { context, gain, limiter };
-    runtime.graphs.set(media, graph);
-    return graph;
-  } catch (error) {
-    console.warn("Could not initialize Web Audio volume normalization", error);
-    return null;
-  }
-}
-
 function applyRuntimeGain(): void {
   const waveSurfer = runtime.activeWaveSurfer;
   if (!waveSurfer || !runtime.rawSetVolume) return;
-
-  if (runtime.useWebAudioGain) {
-    const graph = ensureAudioGraph(waveSurfer);
-    if (graph) {
-      runtime.rawSetVolume(waveSurfer, runtime.baseVolume);
-      graph.gain.gain.setTargetAtTime(runtime.gain, graph.context.currentTime, 0.015);
-      if (graph.context.state === "suspended") void graph.context.resume().catch(() => undefined);
-      return;
-    }
-  }
-
-  runtime.rawSetVolume(waveSurfer, getFallbackVolume(runtime.baseVolume, runtime.gain));
+  runtime.rawSetVolume(waveSurfer, clamp(runtime.baseVolume * runtime.gain, 0, 1));
 }
 
 if (!runtime.patched) {
@@ -119,7 +65,6 @@ if (!runtime.patched) {
     runtime.activeWaveSurfer = waveSurfer;
     runtime.baseVolume = 1;
     runtime.gain = 1;
-    runtime.useWebAudioGain = false;
     return waveSurfer;
   }) as typeof WaveSurfer.create;
 
@@ -135,7 +80,6 @@ if (!runtime.patched) {
       runtime.activeTrack = null;
       runtime.baseVolume = 1;
       runtime.gain = 1;
-      runtime.useWebAudioGain = false;
     }
     return rawDestroy.call(this);
   };
@@ -217,9 +161,8 @@ async function decodeTrackForNormalization(track: LibraryTrack): Promise<AudioBu
   return decodeAudioTrack(track, window.playhead.readAudioFile);
 }
 
-function setPlaybackNormalizationGain(gain: number, allowBoost: boolean): void {
-  runtime.gain = Number.isFinite(gain) ? clamp(gain, 0.25, 2) : 1;
-  runtime.useWebAudioGain = allowBoost;
+function setPlaybackNormalizationGain(gain: number): void {
+  runtime.gain = Number.isFinite(gain) ? clamp(gain, 0.25, 1) : 1;
   applyRuntimeGain();
 }
 
@@ -265,7 +208,7 @@ export async function applyTrackVolumeNormalization(track: LibraryTrack | null):
   runtime.activeTrack = track;
 
   if (!track) {
-    setPlaybackNormalizationGain(1, false);
+    setPlaybackNormalizationGain(1);
     return;
   }
 
@@ -279,16 +222,14 @@ export async function applyTrackVolumeNormalization(track: LibraryTrack | null):
 
   if (requestId !== runtime.requestId || runtime.activeTrack?.id !== track.id) return;
   if (!enabled) {
-    setPlaybackNormalizationGain(1, false);
+    setPlaybackNormalizationGain(1);
     return;
   }
 
-  const allowBoost = track.source !== "soundcloud" && !track.soundcloud;
   const cachedGain = getCachedTrackNormalizationGain(track);
-  if (cachedGain !== null) setPlaybackNormalizationGain(cachedGain, allowBoost);
-  else setPlaybackNormalizationGain(1, allowBoost);
+  setPlaybackNormalizationGain(cachedGain ?? 1);
 
   const gain = await analyzeTrackNormalizationGain(track);
   if (requestId !== runtime.requestId || runtime.activeTrack?.id !== track.id) return;
-  setPlaybackNormalizationGain(gain, allowBoost);
+  setPlaybackNormalizationGain(gain);
 }

--- a/src/renderer/src/features/audio/volume-normalization.ts
+++ b/src/renderer/src/features/audio/volume-normalization.ts
@@ -18,12 +18,22 @@ type CachedNormalization = {
 
 type NormalizationCache = Record<string, CachedNormalization>;
 
+type AudioGraph = {
+  context: AudioContext;
+  gain: GainNode;
+  limiter: DynamicsCompressorNode;
+};
+
 type VolumeNormalizationRuntime = {
   patched: boolean;
   activeWaveSurfer: WaveSurfer | null;
   baseVolume: number;
   gain: number;
-  setRawVolume: ((waveSurfer: WaveSurfer, volume: number) => void) | null;
+  useWebAudioGain: boolean;
+  rawSetVolume: ((waveSurfer: WaveSurfer, volume: number) => void) | null;
+  graphs: WeakMap<HTMLMediaElement, AudioGraph>;
+  activeTrack: LibraryTrack | null;
+  requestId: number;
 };
 
 const globalScope = globalThis as typeof globalThis & {
@@ -36,33 +46,96 @@ const runtime =
     activeWaveSurfer: null,
     baseVolume: 1,
     gain: 1,
-    setRawVolume: null,
+    useWebAudioGain: false,
+    rawSetVolume: null,
+    graphs: new WeakMap<HTMLMediaElement, AudioGraph>(),
+    activeTrack: null,
+    requestId: 0,
   });
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function getEffectiveVolume(baseVolume: number, gain: number): number {
-  return clamp(baseVolume * gain, 0, 1);
+function getFallbackVolume(baseVolume: number, gain: number): number {
+  return clamp(baseVolume * Math.min(gain, 1), 0, 1);
+}
+
+function configureLimiter(limiter: DynamicsCompressorNode): void {
+  limiter.threshold.value = -1;
+  limiter.knee.value = 0;
+  limiter.ratio.value = 20;
+  limiter.attack.value = 0.003;
+  limiter.release.value = 0.1;
+}
+
+function ensureAudioGraph(waveSurfer: WaveSurfer): AudioGraph | null {
+  const media = waveSurfer.getMediaElement();
+  const existing = runtime.graphs.get(media);
+  if (existing) return existing;
+
+  try {
+    const context = new AudioContext();
+    const source = context.createMediaElementSource(media);
+    const gain = context.createGain();
+    const limiter = context.createDynamicsCompressor();
+    configureLimiter(limiter);
+    source.connect(gain).connect(limiter).connect(context.destination);
+    const graph = { context, gain, limiter };
+    runtime.graphs.set(media, graph);
+    return graph;
+  } catch (error) {
+    console.warn("Could not initialize Web Audio volume normalization", error);
+    return null;
+  }
+}
+
+function applyRuntimeGain(): void {
+  const waveSurfer = runtime.activeWaveSurfer;
+  if (!waveSurfer || !runtime.rawSetVolume) return;
+
+  if (runtime.useWebAudioGain) {
+    const graph = ensureAudioGraph(waveSurfer);
+    if (graph) {
+      runtime.rawSetVolume(waveSurfer, runtime.baseVolume);
+      graph.gain.gain.setTargetAtTime(runtime.gain, graph.context.currentTime, 0.015);
+      if (graph.context.state === "suspended") void graph.context.resume().catch(() => undefined);
+      return;
+    }
+  }
+
+  runtime.rawSetVolume(waveSurfer, getFallbackVolume(runtime.baseVolume, runtime.gain));
 }
 
 if (!runtime.patched) {
+  const rawCreate = WaveSurfer.create.bind(WaveSurfer);
   const rawSetVolume = WaveSurfer.prototype.setVolume;
   const rawDestroy = WaveSurfer.prototype.destroy;
 
-  runtime.setRawVolume = (waveSurfer, volume) => rawSetVolume.call(waveSurfer, volume);
+  runtime.rawSetVolume = (waveSurfer, volume) => rawSetVolume.call(waveSurfer, volume);
+
+  WaveSurfer.create = ((options: Parameters<typeof WaveSurfer.create>[0]) => {
+    const waveSurfer = rawCreate(options);
+    runtime.activeWaveSurfer = waveSurfer;
+    runtime.baseVolume = 1;
+    runtime.gain = 1;
+    runtime.useWebAudioGain = false;
+    return waveSurfer;
+  }) as typeof WaveSurfer.create;
 
   WaveSurfer.prototype.setVolume = function setVolumeWithNormalization(volume: number) {
     runtime.activeWaveSurfer = this;
     runtime.baseVolume = clamp(volume, 0, 1);
-    runtime.setRawVolume?.(this, getEffectiveVolume(runtime.baseVolume, runtime.gain));
+    applyRuntimeGain();
   };
 
   WaveSurfer.prototype.destroy = function destroyWithNormalizationCleanup() {
     if (runtime.activeWaveSurfer === this) {
       runtime.activeWaveSurfer = null;
+      runtime.activeTrack = null;
       runtime.baseVolume = 1;
+      runtime.gain = 1;
+      runtime.useWebAudioGain = false;
     }
     return rawDestroy.call(this);
   };
@@ -144,17 +217,10 @@ async function decodeTrackForNormalization(track: LibraryTrack): Promise<AudioBu
   return decodeAudioTrack(track, window.playhead.readAudioFile);
 }
 
-export function setPlaybackNormalizationGain(gain: number): void {
+function setPlaybackNormalizationGain(gain: number, allowBoost: boolean): void {
   runtime.gain = Number.isFinite(gain) ? clamp(gain, 0.25, 2) : 1;
-
-  const waveSurfer = runtime.activeWaveSurfer;
-  if (!waveSurfer || !runtime.setRawVolume) return;
-
-  try {
-    runtime.setRawVolume(waveSurfer, getEffectiveVolume(runtime.baseVolume, runtime.gain));
-  } catch {
-    // The WaveSurfer instance may already be tearing down.
-  }
+  runtime.useWebAudioGain = allowBoost;
+  applyRuntimeGain();
 }
 
 export function getCachedTrackNormalizationGain(track: LibraryTrack): number | null {
@@ -191,4 +257,38 @@ export function analyzeTrackNormalizationGain(track: LibraryTrack): Promise<numb
 
   analysisPromises.set(cacheKey, analysis);
   return analysis;
+}
+
+export async function applyTrackVolumeNormalization(track: LibraryTrack | null): Promise<void> {
+  const requestId = runtime.requestId + 1;
+  runtime.requestId = requestId;
+  runtime.activeTrack = track;
+
+  if (!track) {
+    setPlaybackNormalizationGain(1, false);
+    return;
+  }
+
+  let enabled = false;
+  try {
+    const library = await window.playhead.getLibraryState();
+    enabled = library.settings.playback.normalizeVolume;
+  } catch (error) {
+    console.warn("Could not read volume normalization setting", error);
+  }
+
+  if (requestId !== runtime.requestId || runtime.activeTrack?.id !== track.id) return;
+  if (!enabled) {
+    setPlaybackNormalizationGain(1, false);
+    return;
+  }
+
+  const allowBoost = track.source !== "soundcloud" && !track.soundcloud;
+  const cachedGain = getCachedTrackNormalizationGain(track);
+  if (cachedGain !== null) setPlaybackNormalizationGain(cachedGain, allowBoost);
+  else setPlaybackNormalizationGain(1, allowBoost);
+
+  const gain = await analyzeTrackNormalizationGain(track);
+  if (requestId !== runtime.requestId || runtime.activeTrack?.id !== track.id) return;
+  setPlaybackNormalizationGain(gain, allowBoost);
 }

--- a/src/renderer/src/features/audio/volume-normalization.ts
+++ b/src/renderer/src/features/audio/volume-normalization.ts
@@ -1,0 +1,194 @@
+import WaveSurfer from "wavesurfer.js";
+import type { LibraryTrack } from "../../../../shared/library";
+import {
+  decodeAudioBytes,
+  decodeAudioTrack,
+  estimateIntegratedLoudnessDb,
+  getLoudnessNormalizationGain,
+} from "./audio-analysis";
+
+const normalizationCacheStorageKey = "playhead:volume-normalization-cache:v1";
+const normalizationCacheLimit = 2_000;
+
+type CachedNormalization = {
+  gain: number;
+  loudnessDb: number;
+  analyzedAt: number;
+};
+
+type NormalizationCache = Record<string, CachedNormalization>;
+
+type VolumeNormalizationRuntime = {
+  patched: boolean;
+  activeWaveSurfer: WaveSurfer | null;
+  baseVolume: number;
+  gain: number;
+  setRawVolume: ((waveSurfer: WaveSurfer, volume: number) => void) | null;
+};
+
+const globalScope = globalThis as typeof globalThis & {
+  __playheadVolumeNormalizationRuntime?: VolumeNormalizationRuntime;
+};
+const runtime =
+  globalScope.__playheadVolumeNormalizationRuntime ||
+  (globalScope.__playheadVolumeNormalizationRuntime = {
+    patched: false,
+    activeWaveSurfer: null,
+    baseVolume: 1,
+    gain: 1,
+    setRawVolume: null,
+  });
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function getEffectiveVolume(baseVolume: number, gain: number): number {
+  return clamp(baseVolume * gain, 0, 1);
+}
+
+if (!runtime.patched) {
+  const rawSetVolume = WaveSurfer.prototype.setVolume;
+  const rawDestroy = WaveSurfer.prototype.destroy;
+
+  runtime.setRawVolume = (waveSurfer, volume) => rawSetVolume.call(waveSurfer, volume);
+
+  WaveSurfer.prototype.setVolume = function setVolumeWithNormalization(volume: number) {
+    runtime.activeWaveSurfer = this;
+    runtime.baseVolume = clamp(volume, 0, 1);
+    runtime.setRawVolume?.(this, getEffectiveVolume(runtime.baseVolume, runtime.gain));
+  };
+
+  WaveSurfer.prototype.destroy = function destroyWithNormalizationCleanup() {
+    if (runtime.activeWaveSurfer === this) {
+      runtime.activeWaveSurfer = null;
+      runtime.baseVolume = 1;
+    }
+    return rawDestroy.call(this);
+  };
+
+  runtime.patched = true;
+}
+
+let normalizationCache: NormalizationCache | null = null;
+const analysisPromises = new Map<string, Promise<number>>();
+
+function getNormalizationCache(): NormalizationCache {
+  if (normalizationCache) return normalizationCache;
+  normalizationCache = {};
+  if (typeof localStorage === "undefined") return normalizationCache;
+
+  try {
+    const raw = localStorage.getItem(normalizationCacheStorageKey);
+    if (!raw) return normalizationCache;
+    const parsed = JSON.parse(raw) as NormalizationCache;
+    if (parsed && typeof parsed === "object") normalizationCache = parsed;
+  } catch {
+    normalizationCache = {};
+  }
+
+  return normalizationCache;
+}
+
+function getTrackCacheKey(track: LibraryTrack): string {
+  const sourceKey = track.soundcloud
+    ? `soundcloud:${track.soundcloud.id}`
+    : `${track.source || "local"}:${track.id}`;
+  return [
+    sourceKey,
+    Math.round((track.duration || 0) * 1_000),
+    track.fileName,
+    track.sampleRate || 0,
+    track.bitRate || 0,
+  ].join("|");
+}
+
+function saveNormalizationCacheEntry(
+  cacheKey: string,
+  loudnessDb: number,
+  gain: number,
+): void {
+  const cache = getNormalizationCache();
+  cache[cacheKey] = { gain, loudnessDb, analyzedAt: Date.now() };
+
+  const entries = Object.entries(cache);
+  if (entries.length > normalizationCacheLimit) {
+    entries
+      .sort(([, a], [, b]) => b.analyzedAt - a.analyzedAt)
+      .slice(normalizationCacheLimit)
+      .forEach(([key]) => delete cache[key]);
+  }
+
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(normalizationCacheStorageKey, JSON.stringify(cache));
+  } catch {
+    // Cache persistence is optional. Normalization still works for this session.
+  }
+}
+
+async function decodeTrackForNormalization(track: LibraryTrack): Promise<AudioBuffer | null> {
+  if (track.source === "soundcloud" || track.soundcloud) {
+    const soundcloud = track.soundcloud;
+    if (!soundcloud || !track.duration || track.duration > 480) return null;
+
+    const bytes = await window.playhead.getSoundCloudAnalysisAudioData(
+      soundcloud.id,
+      track.duration,
+      soundcloud.transcodings,
+      soundcloud.trackAuthorization,
+    );
+    return bytes ? decodeAudioBytes(bytes) : null;
+  }
+
+  return decodeAudioTrack(track, window.playhead.readAudioFile);
+}
+
+export function setPlaybackNormalizationGain(gain: number): void {
+  runtime.gain = Number.isFinite(gain) ? clamp(gain, 0.25, 2) : 1;
+
+  const waveSurfer = runtime.activeWaveSurfer;
+  if (!waveSurfer || !runtime.setRawVolume) return;
+
+  try {
+    runtime.setRawVolume(waveSurfer, getEffectiveVolume(runtime.baseVolume, runtime.gain));
+  } catch {
+    // The WaveSurfer instance may already be tearing down.
+  }
+}
+
+export function getCachedTrackNormalizationGain(track: LibraryTrack): number | null {
+  const cached = getNormalizationCache()[getTrackCacheKey(track)];
+  return cached && Number.isFinite(cached.gain) ? cached.gain : null;
+}
+
+export function analyzeTrackNormalizationGain(track: LibraryTrack): Promise<number> {
+  const cacheKey = getTrackCacheKey(track);
+  const cached = getNormalizationCache()[cacheKey];
+  if (cached && Number.isFinite(cached.gain)) return Promise.resolve(cached.gain);
+
+  const pending = analysisPromises.get(cacheKey);
+  if (pending) return pending;
+
+  const analysis = (async () => {
+    try {
+      const buffer = await decodeTrackForNormalization(track);
+      if (!buffer) return 1;
+
+      const loudnessDb = estimateIntegratedLoudnessDb(buffer);
+      if (loudnessDb === null) return 1;
+
+      const gain = getLoudnessNormalizationGain(loudnessDb);
+      saveNormalizationCacheEntry(cacheKey, loudnessDb, gain);
+      return gain;
+    } catch (error) {
+      console.warn("Failed to analyze track loudness", { path: track.path, error });
+      return 1;
+    } finally {
+      analysisPromises.delete(cacheKey);
+    }
+  })();
+
+  analysisPromises.set(cacheKey, analysis);
+  return analysis;
+}

--- a/src/renderer/src/features/player/Player.tsx
+++ b/src/renderer/src/features/player/Player.tsx
@@ -1,8 +1,6 @@
-import { useEffect } from "react";
 import type { LibraryTag, LibraryTrack } from "../../../../shared/library";
 import { AnimatePresence, motion } from "framer-motion";
 import { SliderComfortable } from "@/components/ui/slider";
-import { applyTrackVolumeNormalization } from "@/features/audio/volume-normalization";
 import { formatTime } from "@/lib/format";
 import { useIcons } from "@/lib/icon-context";
 import type { MenuAnchorPoint } from "@/lib/menu-position";
@@ -95,10 +93,6 @@ export function Player({
     : [];
   const visibleTags = activeTags.slice(0, 3);
   const hiddenTagCount = Math.max(0, activeTags.length - visibleTags.length);
-
-  useEffect(() => {
-    void applyTrackVolumeNormalization(activeTrack);
-  }, [activeTrack, isPlaying]);
 
   return (
     <section className="relative flex shrink-0 flex-col gap-[10px] px-4 pt-4">

--- a/src/renderer/src/features/player/Player.tsx
+++ b/src/renderer/src/features/player/Player.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from "react";
 import type { LibraryTag, LibraryTrack } from "../../../../shared/library";
 import { AnimatePresence, motion } from "framer-motion";
 import { SliderComfortable } from "@/components/ui/slider";
+import { applyTrackVolumeNormalization } from "@/features/audio/volume-normalization";
 import { formatTime } from "@/lib/format";
 import { useIcons } from "@/lib/icon-context";
 import type { MenuAnchorPoint } from "@/lib/menu-position";
@@ -93,6 +95,10 @@ export function Player({
     : [];
   const visibleTags = activeTags.slice(0, 3);
   const hiddenTagCount = Math.max(0, activeTags.length - visibleTags.length);
+
+  useEffect(() => {
+    void applyTrackVolumeNormalization(activeTrack);
+  }, [activeTrack, isPlaying]);
 
   return (
     <section className="relative flex shrink-0 flex-col gap-[10px] px-4 pt-4">

--- a/src/renderer/src/features/settings/PlaybackSettingsPane.tsx
+++ b/src/renderer/src/features/settings/PlaybackSettingsPane.tsx
@@ -44,6 +44,12 @@ export function PlaybackSettingsPane({
         />
 
         <PlaybackSwitch
+          title="Normalize volume"
+          description="Keep perceived loudness more consistent when switching between tracks."
+          checked={settings.normalizeVolume}
+          onCheckedChange={(checked) => onChange({ ...settings, normalizeVolume: checked })}
+        />
+        <PlaybackSwitch
           title="Remember playback position"
           description="Resume tracks where you left off."
           checked={settings.rememberTrackPositions}

--- a/src/renderer/src/features/settings/PlaybackSettingsPane.tsx
+++ b/src/renderer/src/features/settings/PlaybackSettingsPane.tsx
@@ -53,9 +53,7 @@ export function PlaybackSettingsPane({
           title="Remember playback position"
           description="Resume tracks where you left off."
           checked={settings.rememberTrackPositions}
-          onCheckedChange={(checked) =>
-            onChange({ ...settings, rememberTrackPositions: checked })
-          }
+          onCheckedChange={(checked) => onChange({ ...settings, rememberTrackPositions: checked })}
         />
         <PlaybackSwitch
           title="Restore last session"

--- a/src/renderer/src/features/settings/SettingsDialog.tsx
+++ b/src/renderer/src/features/settings/SettingsDialog.tsx
@@ -172,6 +172,7 @@ export function SettingsDialog({
   const playbackSettingsChanged =
     savedPlaybackSettings.seekStepSeconds !== draftPlaybackSettings.seekStepSeconds ||
     savedPlaybackSettings.volumeStepPercent !== draftPlaybackSettings.volumeStepPercent ||
+    savedPlaybackSettings.normalizeVolume !== draftPlaybackSettings.normalizeVolume ||
     savedPlaybackSettings.rememberTrackPositions !== draftPlaybackSettings.rememberTrackPositions ||
     savedPlaybackSettings.restoreLastSession !== draftPlaybackSettings.restoreLastSession ||
     savedPlaybackSettings.skipUnavailableTracks !== draftPlaybackSettings.skipUnavailableTracks;

--- a/src/renderer/src/features/updates/update-messages.tsx
+++ b/src/renderer/src/features/updates/update-messages.tsx
@@ -62,4 +62,13 @@ export const updateMessagesByVersion: Record<string, UpdateMessage> = {
     ),
     buttonLabel: "Got it",
   },
+  "0.2.3": {
+    title: "Playhead has been updated",
+    description: (
+      <ul>
+        <li>Added volume normalization</li>
+      </ul>
+    ),
+    buttonLabel: "Got it",
+  },
 };

--- a/src/shared/library.ts
+++ b/src/shared/library.ts
@@ -313,6 +313,11 @@ export type WaveformCacheRequest = {
   duration: number;
 };
 
+export type AudioFileRevision = {
+  size: number;
+  mtimeMs: number;
+};
+
 export type WaveformCacheEntry = {
   duration: number;
   peaks: number[][];
@@ -348,6 +353,7 @@ export type PlayheadApi = {
   getDroppedFilePath: (file: File) => string;
   getAudioFileUrl: (path: string) => Promise<string>;
   readAudioFile: (path: string) => Promise<ArrayBuffer>;
+  getAudioFileRevision: (path: string) => Promise<AudioFileRevision>;
   getWaveformCache: (request: WaveformCacheRequest) => Promise<WaveformCacheEntry | null>;
   saveWaveformCache: (write: WaveformCacheWrite) => Promise<void>;
   getBpmCache: (request: BpmCacheRequest) => Promise<BpmCacheEntry | null>;

--- a/src/shared/library.ts
+++ b/src/shared/library.ts
@@ -222,6 +222,7 @@ export type LibrarySettings = {
 export type PlaybackSettings = {
   seekStepSeconds: number;
   volumeStepPercent: number;
+  normalizeVolume: boolean;
   rememberTrackPositions: boolean;
   restoreLastSession: boolean;
   skipUnavailableTracks: boolean;
@@ -435,6 +436,7 @@ export const defaultLibrarySettings = (): LibrarySettings => ({
 export const defaultPlaybackSettings = (): PlaybackSettings => ({
   seekStepSeconds: 5,
   volumeStepPercent: 5,
+  normalizeVolume: false,
   rememberTrackPositions: true,
   restoreLastSession: true,
   skipUnavailableTracks: true,


### PR DESCRIPTION
Adds an opt-in **Normalize volume** setting under Playback.

### What it does
- estimates integrated loudness from decoded audio
- targets a conservative -18 dB reference
- attenuates louder tracks automatically when switching tracks
- caches per-track normalization gain locally so repeat playback is instant
- supports local tracks and SoundCloud analysis without changing the streaming pipeline
- keeps the user's volume slider as the base volume

### Safety / first-pass behavior
This version is intentionally attenuation-only. It does not boost quiet tracks above their original level, which avoids clipping and avoids routing SoundCloud through Web Audio. That makes it safer to test while still fixing the common case where differently mastered tracks jump much louder than one another.

### Test
1. Open Settings → Playback and enable **Normalize volume**.
2. Play a playlist with noticeably different mastering levels.
3. Switch between loud modern tracks and quieter older tracks/albums.
4. Disable the setting and compare.

Unit coverage was added for loudness estimation, silence handling, target gain, and gain clamping.